### PR TITLE
Use an EnvironmentFile with the systemd service

### DIFF
--- a/debian/matrix-synapse.default
+++ b/debian/matrix-synapse.default
@@ -1,0 +1,2 @@
+# Specify environment variables used when running Synapse
+# SYNAPSE_CACHE_FACTOR=1 (default)

--- a/debian/matrix-synapse.service
+++ b/debian/matrix-synapse.service
@@ -5,6 +5,7 @@ Description=Synapse Matrix homeserver
 Type=simple
 User=matrix-synapse
 WorkingDirectory=/var/lib/matrix-synapse
+EnvironmentFile=/etc/default/matrix-synapse
 ExecStartPre=/usr/bin/python -m synapse.app.homeserver --config-path=/etc/matrix-synapse/homeserver.yaml --config-path=/etc/matrix-synapse/conf.d/ --generate-keys
 ExecStart=/usr/bin/python -m synapse.app.homeserver --config-path=/etc/matrix-synapse/homeserver.yaml --config-path=/etc/matrix-synapse/conf.d/
 Restart=always


### PR DESCRIPTION
In order to allow users to adjust the environment variables surrounding the synapse service, such as `SYNAPSE_CACHE_FACTOR`, without needing to edit the service definition itself (which is overwritten on package upgrades), this adds an `EnvironmentFile` directive to the service definition along with an example file.

My apologies for any Debian packaging mistakes or faux-pas, I have no experience with this.

Signed-off-by: Bryce Chidester <bryce@cobryce.com>