### PR TITLE
Remove `level` for `file` log handler

### DIFF
--- a/debian/log.yaml
+++ b/debian/log.yaml
@@ -18,7 +18,6 @@ handlers:
     maxBytes: 104857600
     backupCount: 10
     filters: [context]
-    level: INFO
   console:
     class: logging.StreamHandler
     formatter: precise


### PR DESCRIPTION
I don't know why we have this, and it *always* confuses people who try to enable debugging