### PR TITLE
Wrap and sort debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,16 +8,20 @@ Build-Depends:
  dh-systemd (>= 1.5),
  po-debconf,
  python (>= 2.6.6-3),
+ python-attr,
  python-bcrypt,
  python-blist,
- python-canonicaljson (>=1.1.3),
+ python-canonicaljson (>= 1.1.3),
  python-daemonize,
  python-frozendict (>= 0.4),
+ python-jsonschema (>= 2.5.1),
  python-mock,
- python-msgpack (>=0.3.0),
+ python-msgpack (>= 0.3.0),
  python-nacl (>= 0.3.0),
  python-openssl (>= 0.14),
+ python-phonenumbers (>= 8.2.0),
  python-pil,
+ python-prometheus-client,
  python-pyasn1,
  python-pydenticon,
  python-pymacaroons-pynacl,
@@ -29,32 +33,28 @@ Build-Depends:
  python-syutil (>= 0.0.7),
  python-twisted (>= 17.1.0),
  python-unpaddedbase64 (>= 1.0.1),
- python-yaml,
- python-phonenumbers (>= 8.2.0),
- python-jsonschema (>=2.5.1),
- python-prometheus-client,
- python-attr
+ python-yaml
 Standards-Version: 3.9.8
 X-Python-Version: >= 2.7
 
 Package: matrix-synapse
 Architecture: all
 Depends:
- ${misc:Depends},
- ${python:Depends},
  adduser,
  debconf,
  lsb-base (>= 3.0-6),
- python-twisted (>= 17.1.0),
  python-bcrypt,
- python-canonicaljson (>=1.1.3),
- python-prometheus-client (>=0.0.14),
+ python-canonicaljson (>= 1.1.3),
+ python-prometheus-client (>= 0.0.14),
+ python-twisted (>= 17.1.0),
+ ${misc:Depends},
+ ${python:Depends}
 Suggests:
  python-bleach (>= 1.4.2),
- python-jinja2 (>= 2.8),
+ python-jinja2 (>= 2.8)
 Recommends:
- python-psycopg2,
  python-lxml,
+ python-psycopg2,
 Description: Open federated Instant Messaging and VoIP server
  Matrix is an ambitious new ecosystem for open federated Instant
  Messaging and VoIP. Synapse is a reference Matrix server


### PR DESCRIPTION
Wrap and sort debian/control so it is easier to compare with the Git branch Debian’s pkg-matrix-team packaging lives in.