### PR TITLE
Default SYNAPSE_CACHE_FACTOR is actually 0.5

### DIFF
--- a/debian/matrix-synapse.default
+++ b/debian/matrix-synapse.default
@@ -1,2 +1,2 @@
 # Specify environment variables used when running Synapse
-# SYNAPSE_CACHE_FACTOR=1 (default)
+# SYNAPSE_CACHE_FACTOR=0.5 (default)


### PR DESCRIPTION
`@tyler:tylerfreedman.com` noticed this https://matrix.to/#/!DYgXKezaHgMbiPMzjX:matrix.org/$1540062697277BQGcG:tylerfreedman.com