### PR TITLE
fix sysvinit for matrix-synapse-py3

### DIFF
--- a/debian/matrix-synapse.init
+++ b/debian/matrix-synapse.init
@@ -21,7 +21,7 @@ DESC="matrix-synapse"
 NAME=matrix-synapse
 SCRIPTNAME=/etc/init.d/$NAME
 
-PYTHON="/usr/bin/python"
+PYTHON="/opt/venvs/matrix-synapse/bin/python"
 CONFIGS="--config-path /etc/matrix-synapse/homeserver.yaml --config-path /etc/matrix-synapse/conf.d/"
 USER="matrix-synapse"
 SHAREDIR=/var/lib/$NAME
@@ -42,7 +42,7 @@ SHAREDIR=/var/lib/$NAME
 
 get_config_key()
 {
-	python -m synapse.config read "$1" $CONFIGS || return 2
+	$PYTHON -m synapse.config read "$1" $CONFIGS || return 2
 }
 
 #


### PR DESCRIPTION
this works but you require to apply first:

https://github.com/matrix-org/synapse/issues/4350 -> https://github.com/matrix-org/synapse/pull/4356

warning, the `PYTHON` variable (line 24) is pointing to python3 for the matrix-synapse-py3 package, I don't know if it can make fail the python2 one